### PR TITLE
Add CLI tool for querying combat database

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,31 @@
+
 # swtor_combat_explorer
 
-This is the swtor_combat_explorer project.
+This is the SW:ToR_Combat_Explorer project. Our goal is to make the
+combat log output from the Star Wars: The Old Republic MMORPG
+programatically accessible from C++ for use in downstream tools, such
+as real-time statistics, offline analyzers, etc.
+
+As of now it consists of two libraries:
+
+1. explorer (swtor_combat_explorer_lib)
+2. populator (swtor_combat_populate_db_lib)
+
+## Explorer (Parser) Library
+
+This library ingests raw textual logfiles emitted by the SW:ToR client
+and produces C++ structures translating the text into C++ types. This
+abstracts away the very idiosyncratic format of the text log and into
+concrete, consistent types easily used by C++ programs.
+
+## DB Populator Library
+
+This library is an example of using C++ types emitted by the parser
+library. Specifically, this library inserts the log data extracted
+from the C++ types into a SQL database. It uses libpqxx, the offical
+C++ PostgreSQL front-end to populate a Postgres database. Making the
+log available in this form allows for aggregate analysis and behavior
+discovery that's very hard to discern from the raw log.
 
 # Building and installing
 
@@ -10,10 +35,28 @@ See the [BUILDING](BUILDING.md) document.
 
 See the [CONTRIBUTING](CONTRIBUTING.md) document.
 
+# What's Missing
+
+Many things, such as:
+
+1. asynchronous input that would allow the parser library to be used
+   in a GUI
+2. handling input from the live log
+3. any usage/testing in Windows, which hosts the majority of SW:ToR
+   clients
+4. a plugin system that would allow analyzers to be plugged in at
+   runtime, giving other developers a simple way perform more
+   sophisticated analyzers, perhaps on a class-by-class basis
+5. any kind of example (or actually useful) GUI.
+6. CI/CD
+7. End-to-end tests - many unit tests, but this is missing.
+8. Automated database creation/deletion. Right now it all has to be
+   done by hand.
+9. Logging is purely textual and to stream, meaning any serious user
+   would have to capture stdout/stderr and parse that (ugly and slow).
+
+That's enough for now. Any more and I'd get too overwhelmed.
+
 # Licensing
 
-<!--
-Please go to https://choosealicense.com/licenses/ and choose a license that
-fits your needs. The recommended license for a project of this type is the
-GNU AGPLv3.
--->
+GNU AGPLv3

--- a/docs/notes.txt
+++ b/docs/notes.txt
@@ -1,6 +1,211 @@
 -*- fil-column: 120; indent-tabs-mode: nil -*-
 
-2025-10-28
+Global to-do:
+
+1) STARTED Start pushing up to GitHub.
+2) Make a container for the build environment.
+3) Add CI/CD via github actions.
+4) STARTED Start using github for doing PRs, etc.
+5) STARTED Analyze gprof results
+6) Performance optimizations, if necessary.
+7) Add another field to Combat that describes the boss. Create table of area/bosses so we can add the boss to the combat when
+   we see them.
+
+2025-11-02
+
+Leftover from yesterday:
+
+Going to do a run with profiling enabled on this log file:
+
+test/logs/combat_2025-04-20_19_52_15_159478.txt
+test/logs/combat_2025-04-20_19_52_15_159478.txt
+
+$ wc -l test/logs/combat_2025-04-20_19_52_15_159478.txt
+336290 test/logs/combat_2025-04-20_19_52_15_159478.txt
+
+$ grep EnterCombat test/logs/combat_2025-04-20_19_52_15_159478.txt | wc -l
+56
+
+$ BL_LEVEL=warning ./build/dev/swtor_combat_populate_db test/logs/combat_2025-04-20_19_52_15_159478.txt >& populate.out
+
+$ wc -l populate.out
+populate.out 336457
+
+swtor_combat_explorer=> select count(*) from event;
+ count  
+--------
+ 336290
+
+Matches perfectly with # of lines in the raw event log. yay.
+
+Why are there more lines in populate.out than rows in the event table?
+
+$ grep -v "Parsing log line" populate.out | wc -l
+167
+
+All I see in these lines are "Did not encounter a double character. Skipping." Hmm.
+
+So, no other errors or warnings. Nice. And this ONLY happens in the "AreaEntered" action that includes the two sentinels
+(he3001) and <v7.0.0b>. Must be the second, since this can be parsed as a double. Let's see. Yeah, not gonna fix
+that. No reason - very simple and occurs infrequently.
+
+Initial timestamp in populate.out:
+
+14:20:54.437478
+
+Final timestamp in populate.out:
+
+15:11:18.752620
+
+About 50m 22s (3022s) for 336290 records. Or, a rough estimate of parsing/population time per event:
+
+0.008s
+
+Ooh, 8ms per event - that's f'ing slow.
+
+swtor_combat_explorer=> select count(*) from event;
+ count  
+--------
+ 336290
+
+Matches perfectly with # of lines in the raw event log. yay.
+
+Here's how we redirect the psql REPL output to a file:
+
+swtor_combat_explorer=> \o populate_events.txt
+swtor_combat_explorer=> select * from event order by ts;
+swtor_combat_explorer=> \o
+
+The "\o file" turns on redirection in the psql REPL and then empty "\o" turns it off. Handy.
+
+Let's rebuild with profiling off and try again.
+
+OK, rebuilt and re-run.
+
+$ BL_LEVEL=warning ./build/dev/swtor_combat_populate_db test/logs/combat_2025-04-20_19_52_15_159478.txt >& populate.out
+
+Interesting question: How many DB transactions do I make? Let's could these up. Huh, I don't see how to do it. :/
+
+OK, some non-profiling results:
+
+First entry timestamp:
+
+15:25:45.962758
+
+Last entry timestamp:
+
+16:17:59.882762
+
+Took about 52m 14s
+
+That makes no sense - it's *slower* than with profiling on. Fuck that.
+
+Oh, well, let's get back to the searching stuff.
+
+OK, got the PCs in combat working. But... I have a problem. The combat is showing just the area name, like "R-4 anomaly"
+and nothing more. I think I need to add some more info to the populator so it shows the boss in the Combat table. Hmm.
+
+So, what would this need?
+
+When we first enter combat, we have the area only but not the boss.
+
+Well, I'd need a list of the names of bosses and then when I encounter the boss during combat, add that boss to the
+combat entry.
+
+So, just make a list of bosses and put that in another database table?
+
+Too much for for now. Make a TODO.
+
+Let's lookat more searches. Issue has info:
+
+    Show all abilities on a per-class basis
+    Given a combat ID and a PC ID, show all the abilities used by that PC in that combat
+    Show all classes
+    Show a count of the number of combats in each area
+
+Getting there. I have these so far:
+
+DEFINE_bool(all_actions,         false, "Show all actions");
+DEFINE_bool(all_action_verbs,    false, "Show just the unique verbs in actions");
+DEFINE_bool(all_class_abilities, false, "Show all abilities per class");
+DEFINE_bool(all_classes,         false, "Show all classes");
+DEFINE_bool(all_combats,         false, "Show all combats");
+DEFINE_bool(pcs_in_combats,      false, "Show all PCs in all combats");
+
+More to do, but that's a start.
+
+I'm not thrilled with gflags. It feels pretty old and unmaintained and clunky. I also really don't like the usage
+format.
+
+2025-11-01
+
+Made a psql script to create the database. Script is makedb.txt. To use:
+
+$ psql -f makedb.txt
+
+(This assumes a bunch of things, like PostgreSQL is installed, you have an account associated with the current user,
+etc. etc.)
+
+Let's try to flesh out the command-line searcher I started last week.
+
+Ooh, created an issue. I love issues. I think I can link the branch to the issue? Not sure how. Oh, you'd create the
+branch, then create a PR for it and then link that PR to the issue. I can also just create the branch from the issue
+page and pull to get it.
+
+That worked well and gives me a consistent naming scheme between the branch and the issue. Good.
+
+Time for lunch.
+
+Going to do a run with profiling enabled on this log file:
+
+test/logs/combat_2025-05-07_19_07_03_273505.txt
+
+$ wc -l test/logs/combat_2025-05-07_19_07_03_273505.txt
+  101798 test/logs/combat_2025-05-07_19_07_03_273505.txt
+
+$ grep EnterCombat test/logs/combat_2025-05-07_19_07_03_273505.txt | wc -l
+19
+
+$ BL_LEVEL=warning ./build/dev/swtor_combat_populate_db test/logs/combat_2025-05-07_19_07_03_273505.txt >& populate.out
+
+
+2025-10-31
+
+Trying to push to github, but no luck. So, github account is "jbtiller". email is jtiller@fastmail.fm.
+
+I didn't have any ssh keys. Created a key, github_jtiller_fastmail_fm_jbtiller_ed25519, and added to github. Still no
+love.
+
+I can test it with ssh via
+
+ssh -T git@github.com -i ~/.ssh/github_jtiller_fastmail_fm_jbtiller_ed25519
+
+which worked. But not connected to git yet.
+
+Can't find anyway on git command line 'push' to specify which key to use.
+
+Added config in ~/.ssh:
+
+Host github.com
+  HostName github.com
+  IdentityFile ~/.ssh/github_jtiller_fastmail_fm_jbtiller_ed25519
+
+Made sure ~/.ssh/config had 600 perms.
+
+Now it's telling me this:
+
+hostkeys_find_by_key_hostfile: hostkeys_foreach failed for /home/jason/.ssh/known_hosts: Permission denied
+The authenticity of host 'github.com (140.82.116.4)' can't be established.
+ED25519 key fingerprint is SHA256:+DiY3wvvV6TuJJhbpZisF/zLDA0zPMSvHdkr4UvCOqU.
+This key is not known by any other names.
+Are you sure you want to continue connecting (yes/no/[fingerprint])? 
+
+I say "yes" and it w3orks!
+
+TODO: Rebuilt with profiling enabled. Run against some logfiles (copy exact command line here). Then store results in a
+subdirectory. Then we can do some local caching (add_name_and_id, add_action, etc.) and see how things change.
+
+2025-10-30
 
 Added logic to specify how to handle populating logfiles that have already been parsed and pushed into the
 database. That's kind of nice.

--- a/makedb.txt
+++ b/makedb.txt
@@ -1,0 +1,13 @@
+# I use this via the psql REPL.
+#
+# From the terminal:
+#
+# psql -f makedb.txt
+
+drop database swtor_combat_explorer;
+
+create database swtor_combat_explorer with encoding 'WIN1252' LC_COLLATE='C' LC_CTYPE='C' TEMPLATE=template0;
+
+\c swtor_combat_explorer
+
+\i db/schema.sql

--- a/source/db_custom_types.hpp
+++ b/source/db_custom_types.hpp
@@ -57,7 +57,6 @@ namespace pqxx {
             assert((end - begin) >= size_buffer(loc));
             auto len = snprintf(begin, size_buffer(loc), "(%.1f,%.1f,%.1f,%.1f)",
                                 loc.x.val(), loc.y.val(), loc.z.val(), loc.rot.val());
-            std::cerr << "string_traits<Location>::to_buf: buf = " << std::quoted(begin) << "\n";
             if (len < 0) {
                 throw conversion_overrun("Overflow buffer for converting Location type");
             }
@@ -139,7 +138,6 @@ namespace pqxx {
             assert((end - begin) >= size_buffer(h));
             auto len = snprintf(begin, size_buffer(h), "(%u,%u)", h.current.val(), h.total.val());
                                 
-            std::cerr << "string_traits<Health>::to_buf: buf = " << std::quoted(begin) << "\n";
             if (len < 0) {
                 throw conversion_overrun("Overflow buffer for converting Health type");
             }

--- a/source/log_parser.cpp
+++ b/source/log_parser.cpp
@@ -84,19 +84,23 @@ auto LogParser::parse_line(sv line, int line_num, Timestamps& ts_parser) -> std:
     }
     line.remove_prefix(dist_beyond_field_delimiter);
 
-    // ability is always present but can be in 3 forms: empty, name/ID, and empty name with ID. WTF?
+    // ability may not be present but can be in 3 forms: empty, name/ID, and empty name with ID. WTF?
     auto ability_field = m_lph.get_next_field(line, '[', ']', &dist_beyond_field_delimiter);
     if (!ability_field) {
         BLT_LINE(fatal, line_num) << "Unable to extract ability field (#4) from log line. Skipping.";
         return {};
     }
 
-    auto ability = m_lph.parse_name_and_id(*ability_field);
+
+    decltype(m_lph.parse_name_and_id(*ability_field)) ability;
     if (ability_field == "") {
-        BLT_LINE(warning, line_num) << "Ability field is empty. Ignoring and continuing.";
-    } else if (!ability) {
-        BLT_LINE(fatal, line_num) << "Failed to successfully parse ability field.";
-        return {};
+        BLT_LINE(info, line_num) << "Ability field is empty. Ignoring and continuing.";
+    } else {
+        ability = m_lph.parse_name_and_id(*ability_field);
+        if (!ability) {
+            BLT_LINE(fatal, line_num) << "Failed to successfully parse ability field.";
+            return {};
+        }
     }
     line.remove_prefix(dist_beyond_field_delimiter);
 

--- a/source/swtor_combat_search_db.cpp
+++ b/source/swtor_combat_search_db.cpp
@@ -1,0 +1,136 @@
+#include <getopt.h>
+#include <iostream>
+
+#include <gflags/gflags.h>
+#include "db_populator.hpp"
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wall"
+#include <pqxx/pqxx>
+#pragma GCC diagnostic pop
+
+DEFINE_bool(all_actions,         false, "Show all actions");
+DEFINE_bool(all_action_verbs,    false, "Show just the unique verbs in actions");
+DEFINE_bool(all_class_abilities, false, "Show all abilities per class");
+DEFINE_bool(all_classes,         false, "Show all classes");
+DEFINE_bool(all_combats,         false, "Show all combats");
+DEFINE_bool(pcs_in_combats,      false, "Show all PCs in all combats");
+
+auto main(int argc, char* argv[]) -> int {
+    gflags::SetUsageMessage("Extract information from the SW:ToR combat database");
+    gflags::ParseCommandLineFlags(&argc, &argv, true);
+
+    auto cx = pqxx::connection{"dbname = swtor_combat_explorer   user = jason   password = jason"};
+    auto tx = pqxx::nontransaction{cx};
+
+    if (FLAGS_all_action_verbs) {
+        std::cout << "You requested all unique verbs in actions.\n";
+        auto res = tx.exec(" SELECT DISTINCT _v.name FROM Action"
+                           "     JOIN Name as _v ON Action.verb = _v.id"
+                           " ORDER BY _v.name");
+        std::cout << "verb\n";
+        for (auto row : res) {
+            auto [verb] = row.as<std::string_view>();
+            std::cout << verb << "\n";
+        }
+    }
+    if (FLAGS_all_actions) {
+        std::cout << "You requested all actions.\n";
+        auto res = tx.exec(" SELECT DISTINCT _v.name, _n.name, _d.name FROM Action AS _a"
+                           "     JOIN Name AS _v ON _a.verb = _v.id"
+                           "     JOIN Name AS _n ON _a.noun = _n.id"
+                           "     JOIN Name AS _d ON _a.detail = _d.id"
+                           " ORDER BY _v.name, _n.name, _d.name");
+        std::cout << "verb,noun,detail\n";
+        for (auto row : res) {
+            auto [verb, noun, detail] = row.as<std::string_view,std::string_view, std::string_view>();
+            std::cout << verb << "," << noun << "," << detail << "\n";
+        }
+    }
+    if (FLAGS_all_class_abilities) {
+        std::cout << "You requested all abilitities for all classes.\n";
+        auto res = tx.exec(" SELECT DISTINCT _style.name, _discipline.name, _ability.name FROM Event"
+                           "     JOIN Actor ON Event.source = Actor.id"
+                           "     JOIN Name AS _ability ON Event.ability = _ability.id"
+                           "     JOIN Advanced_Class AS ac ON Actor.class = ac.id"
+                           "       JOIN Name AS _style ON ac.style = _style.id"
+                           "       JOIN Name AS _discipline ON ac.class = _discipline.id"
+                           " WHERE Event.source IS NOT NULL"
+                           "   AND Actor.type = $1"
+                           "   AND Event.ability IS NOT NULL"
+                           "   AND Actor.class != $2"
+                           " ORDER BY _style.name, _discipline.name, _ability.name",
+                           pqxx::params(DbPopulator::ACTOR_PC_CLASS_TYPE_NAME,
+                                        DbPopulator::UNKNOWN_CLASS_ROW_ID));
+        std::cout << "style,discipline,ability\n";
+        for (auto row : res) {
+            auto [style, discipline, ability] = row.as<std::string_view,std::string_view, std::string_view>();
+            std::cout << style << "," << discipline << "," << ability << "\n";
+        }
+    }
+    if (FLAGS_all_classes) {
+        std::cout << "You requested all classes.\n";
+        auto res = tx.exec(" SELECT style_name.name, discipline_name.name FROM Advanced_Class AS ac" 
+                           "     JOIN Name AS style_name ON ac.style = style_name.id"
+                           "     JOIN Name AS discipline_name ON ac.class = discipline_name.id"
+                           " WHERE ac.id != $1"
+                           " ORDER BY style_name.name, discipline_name.name",
+                           pqxx::params(DbPopulator::UNKNOWN_CLASS_ROW_ID));
+        std::cout << "style,discipline\n";
+        for (auto row : res) {
+            auto [style, discipline] = row.as<std::string_view,std::string_view>();
+            std::cout << style << "," << discipline << "\n";
+        }
+    }
+    if (FLAGS_all_combats) {
+        std::cout << "You requested all combats.\n";
+        auto res = tx.exec("SELECT ts_begin, an.name, lf.filename FROM Combat"
+                           "    JOIN Area as ar  ON Combat.area = ar.id" 
+                           "      JOIN Name as an  ON ar.area = an.id"
+                           "    JOIN Log_File as lf ON combat.logfile = lf.id"
+                           "  ORDER BY an.name");
+        std::cout << "begin_ts,area,logfile\n";
+        for (auto row : res) {
+            auto [begin_ts, area, logfile] = row.as<uint64_t,std::string_view,std::string_view>();
+            std::cout << begin_ts << "," << area << "," << logfile << "\n";
+        }
+    }
+    if (FLAGS_pcs_in_combats) {
+        std::cout << "You requested the PCs for all combats.\n";
+        // auto res = tx.exec("SELECT DISTINCT combat, source FROM Event"
+        //                    "    JOIN Actor on Event.source = Actor.id"
+        //                    " WHERE Actor.type = 'pc' AND combat IS NOT NULL"
+        //                    " GROUP BY combat, source");
+        // std::cout << "combat_id, source_id\n";
+        // for (auto row : res) {
+        //     auto [combat_id, actor_id] = row.as<int, int>();
+        //     std::cout << combat_id << "," << actor_id << "\n";
+        // }
+        // The above works. Now, to get it to display more useful information.
+        // Combat ID, area name & difficulty, PC name
+        auto res = tx.exec("SELECT DISTINCT"
+                           "  combat as combat_id"
+                           ", area_name.name as area_name"
+                           ", difficulty_name.name as difficulty_name"
+                           ", pc_name.name as pc_name"
+                           "    FROM Event"
+                           "     JOIN Combat on Event.combat = Combat.id"
+                           "     JOIN Actor on Event.source = Actor.id"
+                           "       JOIN Name as pc_name ON Actor.name = pc_name.id"
+                           "     JOIN Area on Combat.area = Area.id"
+                           "       JOIN Name as area_name ON area.area = area_name.id"
+                           "       JOIN Name as difficulty_name ON area.difficulty = difficulty_name.id"
+                           " WHERE Actor.type = 'pc' AND combat IS NOT NULL"
+                           " GROUP BY combat_id, area_name, difficulty_name, pc_name"
+                           " ORDER BY combat_id, pc_name");
+        std::cout << "combat, area, area, pc\n";
+        for (auto row : res) {
+            auto [combat_id, area_name, difficulty_name, pc_name] =
+                row.as<int, std::string, std::string, std::string>();
+            std::cout << combat_id << "," << area_name << ", " << difficulty_name << ", " << pc_name << "\n";
+        }
+
+    }
+
+    return 0;
+}


### PR DESCRIPTION
Tool is useful for exploring the database structure and showing examples of queries. DISTINCT queries help give a sense for what kind of actions actors can perform, the PCs in a combat, etc. The searches are all command-line options to the main searcher app. I currently use gflags for option parsing, but I'm not wedded to this library.